### PR TITLE
Switch GitHub streak image URLs to Vercel host

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@
 <p align="center">
 <!-- Streak -->
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://streak-stats.demolab.com?user=Dilyannn&theme=tokyonight&hide_border=true&border_radius=14&card_width=495" />
-  <source media="(prefers-color-scheme: light)" srcset="https://streak-stats.demolab.com?user=Dilyannn&theme=default&hide_border=true&border_radius=14&card_width=495" />
-  <img alt="GitHub Streak" src="https://streak-stats.demolab.com?user=Dilyannn&theme=default&hide_border=true&border_radius=14&card_width=495" height="195" />
+  <source media="(prefers-color-scheme: dark)" srcset="https://github-readme-streak-stats-bice-chi.vercel.app?user=Dilyannn&theme=tokyonight&hide_border=true&border_radius=14&card_width=495" />
+  <source media="(prefers-color-scheme: light)" srcset="https://github-readme-streak-stats-bice-chi.vercel.app?user=Dilyannn&theme=default&hide_border=true&border_radius=14&card_width=495" />
+  <img alt="GitHub Streak" src="https://github-readme-streak-stats-bice-chi.vercel.app?user=Dilyannn&theme=default&hide_border=true&border_radius=14&card_width=495" height="195" />
 </picture>
 </p>
 


### PR DESCRIPTION
### Motivation
- Replace the `streak-stats.demolab.com` image URLs with a Vercel-hosted provider to improve reliability of the GitHub streak card in the `README.md`.

### Description
- Updated three occurrences in `README.md` to use `https://github-readme-streak-stats-bice-chi.vercel.app` for the dark, light, and fallback `img` `src` attributes.

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfa6fdd1a8832b96514dffc5d498ba)