### PR TITLE
Replace Top Languages image endpoints in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@
 <!-- Most Used Languages (below, centered) -->
 <picture>
   <source media="(prefers-color-scheme: dark)"
-    srcset="https://github-readme-stats-dilyan-yanevs-projects.vercel.app/api/top-langs?username=Dilyannn&layout=compact&langs_count=10&card_width=400&theme=tokyonight&hide_border=true&border_radius=14&format=png&v=4" />
+    srcset="https://github-readme-stats-ecru-two-99.vercel.app/api/top-langs?username=Dilyannn&layout=compact&langs_count=10&card_width=400&theme=tokyonight&hide_border=true&border_radius=14&format=png&v=4" />
   <source media="(prefers-color-scheme: light)"
-    srcset="https://github-readme-stats-dilyan-yanevs-projects.vercel.app/api/top-langs?username=Dilyannn&layout=compact&langs_count=10&card_width=400&theme=default&hide_border=true&border_radius=14&format=png&v=4" />
+    srcset="https://github-readme-stats-ecru-two-99.vercel.app/api/top-langs?username=Dilyannn&layout=compact&langs_count=10&card_width=400&theme=default&hide_border=true&border_radius=14&format=png&v=4" />
   <img alt="Top Languages"
-    src="https://github-readme-stats-dilyan-yanevs-projects.vercel.app/api/top-langs?username=Dilyannn&layout=compact&langs_count=10&card_width=400&theme=default&hide_border=true&border_radius=14&format=png&v=4" />
+    src="https://github-readme-stats-ecru-two-99.vercel.app/api/top-langs?username=Dilyannn&layout=compact&langs_count=10&card_width=400&theme=default&hide_border=true&border_radius=14&format=png&v=4" />
 </picture>
 </div>
 


### PR DESCRIPTION
### Motivation
- Point the Top Languages image in `README.md` to the updated stats host by replacing the previous `github-readme-stats-dilyan-yanevs-projects.vercel.app` endpoints with `github-readme-stats-ecru-two-99.vercel.app`.

### Description
- Modified `README.md` to update the `srcset` and `src` values for the Top Languages `<picture>` element to use `https://github-readme-stats-ecru-two-99.vercel.app` instead of the old host.

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfa6fdd1a8832b96514dffc5d498ba)